### PR TITLE
Fix dependency declarations for ESP-NOW PubSub sensors

### DIFF
--- a/components/espnow_pubsub/sensor.py
+++ b/components/espnow_pubsub/sensor.py
@@ -23,7 +23,12 @@ import esphome.config_validation as cv
 from esphome.components import sensor
 from . import espnow_pubsub_ns, EspNowPubSub
 
-DEPENDANCIES = ["espnow_pubsub"]
+# Correctly declare component dependencies so ESPHome ensures the
+# base ``espnow_pubsub`` component is initialized before any sensors.
+# The previous misspelled name (``DEPENDANCIES``) meant this list was
+# ignored, allowing sensors to be registered without the core component
+# being loaded, which could lead to runtime errors.
+DEPENDENCIES = ["espnow_pubsub"]
 
 ESP_NOW_SENSOR_SCHEMA = sensor.sensor_schema(
     unit_of_measurement="dBm",

--- a/components/espnow_pubsub/text_sensor.py
+++ b/components/espnow_pubsub/text_sensor.py
@@ -23,7 +23,11 @@ import esphome.config_validation as cv
 from esphome.components import text_sensor
 from . import espnow_pubsub_ns, EspNowPubSub
 
-DEPENDANCIES = ["espnow_pubsub"]
+# Declare the dependency on the core ``espnow_pubsub`` component. The
+# previous variable name ``DEPENDANCIES`` was misspelled, so ESPHome did
+# not recognize the dependency and the text sensor could be used without
+# the parent component being initialized.
+DEPENDENCIES = ["espnow_pubsub"]
 
 ESP_NOW_TEXT_SENSOR_SCHEMA = text_sensor.text_sensor_schema()
 


### PR DESCRIPTION
## Summary
- Correct dependency constant name for ESP-NOW PubSub sensors and text sensors
- Add explanatory comments

## Testing
- `python -m py_compile components/espnow_pubsub/sensor.py components/espnow_pubsub/text_sensor.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a06fd9a948832784dd8d92d7eaee86