### PR TITLE
Move mqtt_topic_matches helper into namespace

### DIFF
--- a/components/espnow_pubsub/espnow_pubsub.cpp
+++ b/components/espnow_pubsub/espnow_pubsub.cpp
@@ -49,7 +49,7 @@ namespace espnow_pubsub {
 //   sub = "foo/bar", topic = "foo/bar/baz"           => false
 //
 // Called from receive_message() for every incoming message to determine if a subscription matches.
-static bool mqtt_topic_matches(const std::string &sub, const std::string &topic) {
+bool mqtt_topic_matches(const std::string &sub, const std::string &topic) {
   size_t sub_pos = 0, topic_pos = 0;
   // Iterate through both sub and topic, token by token (split by '/')
   while (sub_pos < sub.size() && topic_pos < topic.size()) {

--- a/components/espnow_pubsub/espnow_pubsub.h
+++ b/components/espnow_pubsub/espnow_pubsub.h
@@ -36,12 +36,12 @@
 #include <utility>
 #include <esp_now.h>
 
-// Helper: MQTT topic match with wildcards
-// Supports + (single-level) and # (multi-level) wildcards
-static bool mqtt_topic_matches(const std::string &sub, const std::string &topic);
-
 namespace esphome {
 namespace espnow_pubsub {
+
+// Helper: MQTT topic match with wildcards
+// Supports + (single-level) and # (multi-level) wildcards
+bool mqtt_topic_matches(const std::string &sub, const std::string &topic);
 
 class OnMessageTrigger; // Forward declaration
 


### PR DESCRIPTION
## Summary
- remove global `static` prototype for mqtt_topic_matches
- expose non-static declaration within `esphome::espnow_pubsub` namespace
- update definition to match

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0ac6ec86483279496c1796a3328f5