### PR TITLE
Simplify espnow publish action

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ text_sensor:
 
 # To publish a message from an automation:
 - espnow_pubsub.publish:
-    id: my_pubsub
     topic: "test/topic"
     payload: "hello world"
 ```

--- a/components/espnow_pubsub/__init__.py
+++ b/components/espnow_pubsub/__init__.py
@@ -62,14 +62,13 @@ CONFIG_SCHEMA = cv.Schema(
     EspnowPubSubPublishAction,
     cv.Schema(
         {
-            cv.Required(CONF_ID): cv.use_id(EspNowPubSub),
             cv.Required(CONF_TOPIC): cv.string,
             cv.Required("payload"): cv.templatable(cv.string),
         }
     ),
 )
 async def espnow_pubsub_publish_action_to_code(config, action_id, template_arg, args):
-    var = cg.new_Pvariable(action_id, template_arg, await cg.get_variable(config[CONF_ID]))
+    var = cg.new_Pvariable(action_id, template_arg)
     cg.add(var.set_topic(config[CONF_TOPIC]))
     payload = await cg.templatable(config["payload"], args, cg.std_string)
     cg.add(var.set_payload(payload))

--- a/components/espnow_pubsub/espnow_pubsub.cpp
+++ b/components/espnow_pubsub/espnow_pubsub.cpp
@@ -727,7 +727,9 @@ OnMessageTrigger::OnMessageTrigger(EspNowPubSub *parent, const std::string &topi
 
 // EspnowPubSubPublishAction implementation
 template<typename... Ts>
-EspnowPubSubPublishAction<Ts...>::EspnowPubSubPublishAction(EspNowPubSub *parent) : parent_(parent) {}
+EspnowPubSubPublishAction<Ts...>::EspnowPubSubPublishAction() {
+  parent_ = global_espnow_pubsub_instance;
+}
 
 template<typename... Ts>
 void EspnowPubSubPublishAction<Ts...>::set_topic(const std::string &topic) { topic_ = topic; }
@@ -741,8 +743,9 @@ template<typename... Ts>
 void EspnowPubSubPublishAction<Ts...>::play(Ts... x) {
   auto payload = this->payload_.value(x...);
   ESP_LOGV("espnow_pubsub", "Playing publish action: topic='%s', payload='%s'", topic_.c_str(), payload.c_str());
-  if (parent_ != nullptr) {
-    parent_->publish(topic_, payload);
+  auto *parent = parent_ != nullptr ? parent_ : global_espnow_pubsub_instance;
+  if (parent != nullptr) {
+    parent->publish(topic_, payload);
   }
 }
 

--- a/components/espnow_pubsub/espnow_pubsub.h
+++ b/components/espnow_pubsub/espnow_pubsub.h
@@ -139,13 +139,13 @@ class OnMessageTrigger : public Trigger<std::string, std::string> {
 template<typename... Ts>
 class EspnowPubSubPublishAction : public Action<Ts...> {
  public:
-  explicit EspnowPubSubPublishAction(EspNowPubSub *parent);
+  EspnowPubSubPublishAction();
   void set_topic(const std::string &topic);
   void set_payload(TemplatableValue<std::string, Ts...> payload);
   void play(Ts... x) override;
 
  protected:
-  EspNowPubSub *parent_;
+  EspNowPubSub *parent_ = nullptr;
   std::string topic_;
   TemplatableValue<std::string, Ts...> payload_;
 };


### PR DESCRIPTION
## Summary
- Remove component ID requirement from `espnow_pubsub.publish`
- Use the global espnow_pubsub instance by default
- Update README usage example

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0b90afcf48327ab3a945f0f0eedf1