### PR TITLE
Add sequence numbers with configurable retransmit support

### DIFF
--- a/components/espnow_pubsub/__init__.py
+++ b/components/espnow_pubsub/__init__.py
@@ -39,7 +39,7 @@ espnow_pubsub_ns = cg.esphome_ns.namespace("espnow_pubsub")
 EspNowPubSub = espnow_pubsub_ns.class_("EspNowPubSub", cg.Component)
 # Triggers
 OnMessageTrigger = espnow_pubsub_ns.class_(
-    "OnMessageTrigger", automation.Trigger.template(cg.std_string, cg.std_string, cg.uint32_t)
+    "OnMessageTrigger", automation.Trigger.template(cg.std_string, cg.std_string, cg.uint32)
 )
 # Actions
 EspnowPubSubPublishAction = espnow_pubsub_ns.class_("EspnowPubSubPublishAction", automation.Action)
@@ -125,7 +125,7 @@ async def to_code(config):
                 cg.add(var.add_subscription(sub_conf[CONF_TOPIC], trigger))
                 await automation.build_automation(
                     trigger,
-                    [(cg.std_string, "topic"), (cg.std_string, "payload"), (cg.uint32_t, "sequence")],
+                    [(cg.std_string, "topic"), (cg.std_string, "payload"), (cg.uint32, "sequence")],
                     sub_conf,
                 )
         else:
@@ -133,7 +133,7 @@ async def to_code(config):
             cg.add(var.add_subscription(conf[CONF_TOPIC], trigger))
             await automation.build_automation(
                 trigger,
-                [(cg.std_string, "topic"), (cg.std_string, "payload"), (cg.uint32_t, "sequence")],
+                [(cg.std_string, "topic"), (cg.std_string, "payload"), (cg.uint32, "sequence")],
                 conf,
             )
 

--- a/components/espnow_pubsub/__init__.py
+++ b/components/espnow_pubsub/__init__.py
@@ -38,7 +38,9 @@ from esphome.core import CORE
 espnow_pubsub_ns = cg.esphome_ns.namespace("espnow_pubsub")
 EspNowPubSub = espnow_pubsub_ns.class_("EspNowPubSub", cg.Component)
 # Triggers
-OnMessageTrigger = espnow_pubsub_ns.class_("OnMessageTrigger", automation.Trigger.template(cg.std_string, cg.std_string))
+OnMessageTrigger = espnow_pubsub_ns.class_(
+    "OnMessageTrigger", automation.Trigger.template(cg.std_string, cg.std_string, cg.uint32_t)
+)
 # Actions
 EspnowPubSubPublishAction = espnow_pubsub_ns.class_("EspnowPubSubPublishAction", automation.Action)
 
@@ -121,11 +123,19 @@ async def to_code(config):
             for sub_conf in conf:
                 trigger = cg.new_Pvariable(sub_conf[CONF_TRIGGER_ID], var, sub_conf[CONF_TOPIC])
                 cg.add(var.add_subscription(sub_conf[CONF_TOPIC], trigger))
-                await automation.build_automation(trigger, [(cg.std_string, "topic"), (cg.std_string, "payload")], sub_conf)
+                await automation.build_automation(
+                    trigger,
+                    [(cg.std_string, "topic"), (cg.std_string, "payload"), (cg.uint32_t, "sequence")],
+                    sub_conf,
+                )
         else:
             trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var, conf[CONF_TOPIC])
             cg.add(var.add_subscription(conf[CONF_TOPIC], trigger))
-            await automation.build_automation(trigger, [(cg.std_string, "topic"), (cg.std_string, "payload")], conf)
+            await automation.build_automation(
+                trigger,
+                [(cg.std_string, "topic"), (cg.std_string, "payload"), (cg.uint32_t, "sequence")],
+                conf,
+            )
 
     if CORE.using_esp_idf:
         # Ensure WiFi driver is enabled for ESP-IDF

--- a/components/espnow_pubsub/__init__.py
+++ b/components/espnow_pubsub/__init__.py
@@ -53,6 +53,7 @@ CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(): cv.declare_id(EspNowPubSub),
         cv.Required(CONF_CHANNEL): cv.int_range(1, 14),
+        cv.Optional("send_times", default=1): cv.int_range(min=1, max=10),
         cv.Optional("on_message"): cv.ensure_list(ON_MESSAGE_SCHEMA),
     }
 ).extend(cv.COMPONENT_SCHEMA)
@@ -112,6 +113,7 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     cg.add(var.set_channel(config[CONF_CHANNEL]))
+    cg.add(var.set_send_times(config["send_times"]))
 
     for conf in config.get("on_message", []):
         # Fix: conf may be a list if schema is not flattened

--- a/components/espnow_pubsub/espnow_pubsub.cpp
+++ b/components/espnow_pubsub/espnow_pubsub.cpp
@@ -718,6 +718,7 @@ void EspNowPubSub::dump_config() {
     }
   }
   ESP_LOGCONFIG(TAG, "  WiFi Power Save: %s", ps_str);
+  ESP_LOGCONFIG(TAG, "  Repeat Transmissions: %d", send_times_);
   if (espnow_init_ok_) {
     ESP_LOGCONFIG(TAG, "  ESP-NOW: initialized successfully");
   } else {

--- a/components/espnow_pubsub/espnow_pubsub.cpp
+++ b/components/espnow_pubsub/espnow_pubsub.cpp
@@ -21,9 +21,11 @@
 #include <vector>
 #include <string>
 #include <algorithm>
+#include <cstring>
 #include <esp_now.h>
 #include <esp_event.h>
 #include "esp_wifi.h"
+#include "esp_attr.h"
 #include "espnow_pubsub.h"
 #include "esphome/core/log.h"
 #include "esphome/core/defines.h"
@@ -33,6 +35,8 @@
 
 namespace esphome {
 namespace espnow_pubsub {
+
+RTC_DATA_ATTR static uint32_t rtc_sequence_number = 0;
 
 // MQTT-style topic matching with wildcards.
 // This function checks if a given topic string matches a subscription pattern using MQTT wildcards:
@@ -532,7 +536,8 @@ void EspNowPubSub::loop() {
 }
 
 // publish(): Called to send a message to all ESP-NOW peers (broadcast).
-// Formats the message as topic\0payload and sends via ESP-NOW.
+// Formats the message as [uint32_t seq][topic\0payload] and sends via ESP-NOW
+// multiple times based on send_times_.
 void EspNowPubSub::publish(const std::string &topic, const std::string &payload) {
   ESP_LOGI(TAG, "Publishing message: topic='%s', payload='%s'", topic.c_str(), payload.c_str());
   if (!espnow_init_ok_) {
@@ -543,14 +548,28 @@ void EspNowPubSub::publish(const std::string &topic, const std::string &payload)
 #endif
     return;
   }
-  // Format: topic\0payload
-  std::string msg = topic + '\0' + payload;
+  // Format: [seq][topic\0payload]
+  uint32_t seq = rtc_sequence_number++;
+  std::string msg;
+  msg.resize(sizeof(uint32_t));
+  memcpy(&msg[0], &seq, sizeof(uint32_t));
+  msg += topic;
+  msg.push_back('\0');
+  msg += payload;
+
   uint8_t broadcast_mac[6];
   memset(broadcast_mac, 0xFF, 6);
-  esp_err_t err = esp_now_send(broadcast_mac, reinterpret_cast<const uint8_t *>(msg.data()), msg.size());
+
+  esp_err_t err = ESP_OK;
+  for (int i = 0; i < send_times_; ++i) {
+    err = esp_now_send(broadcast_mac, reinterpret_cast<const uint8_t *>(msg.data()), msg.size());
+    if (err == ESP_OK) {
+      sent_count_++;
+    } else {
+      ESP_LOGE(TAG, "ESP-NOW send failed: %d (0x%04X)", err, (unsigned) err);
+    }
+  }
   if (err != ESP_OK) {
-    // Print error as both decimal and hex for easier ESP-IDF lookup
-    ESP_LOGE(TAG, "ESP-NOW send failed: %d (0x%04X)", err, (unsigned)err);
     switch (err) {
       case ESP_ERR_ESPNOW_NOT_INIT:
         last_status_ = "Send failed: ESP-NOW not initialized (ESP_ERR_ESPNOW_NOT_INIT)";
@@ -571,19 +590,15 @@ void EspNowPubSub::publish(const std::string &topic, const std::string &payload)
         last_status_ = "Send failed: " + std::to_string(err);
         break;
     }
-#ifdef USE_TEXT_SENSOR
-    if (status_text_sensor_) status_text_sensor_->publish_state(last_status_);
-#endif
   } else {
-    sent_count_++;
-#ifdef USE_SENSOR
-    if (sent_count_sensor_) sent_count_sensor_->publish_state(sent_count_);
-#endif
     last_status_ = "OK";
-#ifdef USE_TEXT_SENSOR
-    if (status_text_sensor_) status_text_sensor_->publish_state(last_status_);
-#endif
   }
+#ifdef USE_SENSOR
+  if (sent_count_sensor_) sent_count_sensor_->publish_state(sent_count_);
+#endif
+#ifdef USE_TEXT_SENSOR
+  if (status_text_sensor_) status_text_sensor_->publish_state(last_status_);
+#endif
 }
 
 // on_espnow_receive(): Called from the ESP-NOW receive callback (ISR context).
@@ -602,7 +617,7 @@ void EspNowPubSub::on_espnow_receive(const esp_now_recv_info *recv_info, const u
 #endif
     return;
   }
-  if (len <= 0) {
+  if (len <= (int) sizeof(uint32_t)) {
     ESP_LOGE(TAG, "[ON_RX] len is invalid: %d", len);
     last_status_ = "RX error: invalid len";
 #ifdef USE_TEXT_SENSOR
@@ -610,10 +625,12 @@ void EspNowPubSub::on_espnow_receive(const esp_now_recv_info *recv_info, const u
 #endif
     return;
   }
-  // Parse topic\0payload
-  const char *raw = reinterpret_cast<const char *>(data);
-  int topic_len = strnlen(raw, len);
-  if (topic_len >= len - 1) {
+  // Parse seq + topic\0payload
+  uint32_t seq = 0;
+  memcpy(&seq, data, sizeof(uint32_t));
+  const char *raw = reinterpret_cast<const char *>(data + sizeof(uint32_t));
+  int topic_len = strnlen(raw, len - sizeof(uint32_t));
+  if (topic_len >= len - (int) sizeof(uint32_t) - 1) {
     ESP_LOGE(TAG, "[ON_RX] Malformed ESP-NOW message: topic_len=%d, len=%d", topic_len, len);
     last_status_ = "RX error: malformed message";
 #ifdef USE_TEXT_SENSOR
@@ -622,7 +639,22 @@ void EspNowPubSub::on_espnow_receive(const esp_now_recv_info *recv_info, const u
     return;
   }
   std::string topic(raw, topic_len);
-  std::string payload(raw + topic_len + 1, len - topic_len - 1);
+  std::string payload(raw + topic_len + 1, len - sizeof(uint32_t) - topic_len - 1);
+  std::string mac_key(mac_str);
+  auto it = last_sequence_by_mac_.find(mac_key);
+  if (it != last_sequence_by_mac_.end()) {
+    uint32_t last_seq = it->second;
+    if (seq == last_seq) {
+      ESP_LOGV(TAG, "[ON_RX] Duplicate seq %u from %s ignored", seq, mac_str);
+      return;
+    }
+    if (seq < last_seq) {
+      ESP_LOGV(TAG, "[ON_RX] Sequence reset from %u to %u for %s", last_seq, seq, mac_str);
+    }
+    it->second = seq;
+  } else {
+    last_sequence_by_mac_[mac_key] = seq;
+  }
   ESP_LOGV(TAG, "[ON_RX] Queuing topic='%s', payload='%s' for processing in loop", topic.c_str(), payload.c_str());
   // Message queue overflow handling: drop oldest if full
   if (message_queue_.size() >= MAX_QUEUE_SIZE) {

--- a/components/espnow_pubsub/espnow_pubsub.h
+++ b/components/espnow_pubsub/espnow_pubsub.h
@@ -34,6 +34,7 @@
 #include <functional>
 #include <string>
 #include <utility>
+#include <unordered_map>
 #include <esp_now.h>
 
 namespace esphome {
@@ -74,6 +75,8 @@ class EspNowPubSub : public Component {
   void init_espnow_common();
   // ESP-NOW initialization after WiFi connects and channel is valid
   void init_espnow_after_wifi(uint8_t wifi_channel);
+
+  void set_send_times(int send_times) { send_times_ = send_times; }
   
  // Sensor setters
 #ifdef USE_SENSOR
@@ -127,6 +130,11 @@ class EspNowPubSub : public Component {
   std::vector<QueuedMessage> message_queue_;
   // Maximum number of messages allowed in the queue (overflow handling)
   static constexpr size_t MAX_QUEUE_SIZE = 16;
+
+  int send_times_{1};
+  // Track last seen sequence number per MAC to filter duplicates while
+  // permitting counter resets after a reboot or wrap-around.
+  std::unordered_map<std::string, uint32_t> last_sequence_by_mac_;
 };
 
 // OnMessageTrigger: Trigger for incoming messages on a topic

--- a/components/espnow_pubsub/espnow_pubsub.h
+++ b/components/espnow_pubsub/espnow_pubsub.h
@@ -48,7 +48,7 @@ class OnMessageTrigger; // Forward declaration
 
 class EspNowPubSub : public Component {
  public:
-  using MessageCallback = std::function<void(const std::string &topic, const std::string &payload)>;
+  using MessageCallback = std::function<void(const std::string &topic, const std::string &payload, uint32_t sequence)>;
 
   EspNowPubSub();
   float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }
@@ -63,7 +63,7 @@ class EspNowPubSub : public Component {
   void add_subscription(const std::string &topic, OnMessageTrigger *trigger);
 
   void publish(const std::string &topic, const std::string &payload);
-  void receive_message(const std::string &topic, const std::string &payload);
+  void receive_message(const std::string &topic, const std::string &payload, uint32_t sequence);
   
   void on_espnow_receive(const esp_now_recv_info *recv_info, const uint8_t *mac_addr, const uint8_t *data, int len);
 
@@ -126,6 +126,7 @@ class EspNowPubSub : public Component {
   struct QueuedMessage {
     std::string topic;
     std::string payload;
+    uint32_t sequence;
   };
   std::vector<QueuedMessage> message_queue_;
   // Maximum number of messages allowed in the queue (overflow handling)
@@ -138,7 +139,7 @@ class EspNowPubSub : public Component {
 };
 
 // OnMessageTrigger: Trigger for incoming messages on a topic
-class OnMessageTrigger : public Trigger<std::string, std::string> {
+class OnMessageTrigger : public Trigger<std::string, std::string, uint32_t> {
  public:
   OnMessageTrigger(EspNowPubSub *parent, const std::string &topic);
 };


### PR DESCRIPTION
## Summary
- add persistent sequence numbers to ESP-NOW messages and repeat transmissions
- drop duplicate messages by tracking per-sender sequence numbers
- allow configuring number of send attempts via `send_times`
- reset duplicate tracking when a sender restarts or sequence numbers wrap

## Testing
- `python -m py_compile components/espnow_pubsub/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68b1e6df7e248327a8da528acf1701be