### PR TITLE
feat: make esp-now transmit power configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This component enables MQTT-like pub/sub messaging over ESP-NOW for ESP32 device
 - Robust ESP-NOW pub/sub messaging for ESP32
 - Works with WiFi, Ethernet, or standalone (no network stack)
 - Automatic WiFi driver enablement for ESP-NOW under ESP-IDF/Ethernet
+- Optional transmit power configuration for ESP-NOW messages
 - Broadcast-based (no peer MAC configuration required)
 - Topic-based subscription and message dispatch
 - MQTT-style wildcard topic matching (`+` and `#`)
@@ -38,6 +39,7 @@ external_components:
 espnow_pubsub:
   id: my_pubsub
   channel: 6
+  tx_power: 17
   on_message:
     - topic: "test/topic"
       then:

--- a/components/espnow_pubsub/__init__.py
+++ b/components/espnow_pubsub/__init__.py
@@ -42,6 +42,9 @@ OnMessageTrigger = espnow_pubsub_ns.class_("OnMessageTrigger", automation.Trigge
 # Actions
 EspnowPubSubPublishAction = espnow_pubsub_ns.class_("EspnowPubSubPublishAction", automation.Action)
 
+# Local constants
+CONF_TX_POWER = "tx_power"
+
 ON_MESSAGE_SCHEMA = automation.validate_automation(
     {
         cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(OnMessageTrigger),
@@ -53,6 +56,7 @@ CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(): cv.declare_id(EspNowPubSub),
         cv.Required(CONF_CHANNEL): cv.int_range(1, 14),
+        cv.Optional(CONF_TX_POWER): cv.float_range(min=2.0, max=20.5),
         cv.Optional("on_message"): cv.ensure_list(ON_MESSAGE_SCHEMA),
     }
 ).extend(cv.COMPONENT_SCHEMA)
@@ -112,6 +116,8 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     cg.add(var.set_channel(config[CONF_CHANNEL]))
+    if CONF_TX_POWER in config:
+        cg.add(var.set_tx_power(config[CONF_TX_POWER]))
 
     for conf in config.get("on_message", []):
         # Fix: conf may be a list if schema is not flattened

--- a/components/espnow_pubsub/espnow_pubsub.cpp
+++ b/components/espnow_pubsub/espnow_pubsub.cpp
@@ -21,6 +21,7 @@
 #include <vector>
 #include <string>
 #include <algorithm>
+#include <cmath>
 #include <esp_now.h>
 #include <esp_event.h>
 #include "esp_wifi.h"
@@ -199,6 +200,15 @@ void EspNowPubSub::init_espnow_common() {
   esp_err_t ch_err = esp_wifi_set_channel(channel_, WIFI_SECOND_CHAN_NONE);
   if (ch_err != ESP_OK) {
     ESP_LOGE(TAG, "Failed to set WiFi channel to %d: %d", channel_, (int)ch_err);
+  }
+
+  // Optionally set the WiFi transmit power if configured
+  if (tx_power_ >= 0.0f) {
+    int8_t power = static_cast<int8_t>(std::round(tx_power_ * 4.0f));
+    esp_err_t p_err = esp_wifi_set_max_tx_power(power);
+    if (p_err != ESP_OK) {
+      ESP_LOGW(TAG, "Failed to set WiFi max TX power to %.1f dBm: %d", tx_power_, (int)p_err);
+    }
   }
 
   // 4. Manage WiFi power save:
@@ -668,6 +678,9 @@ void EspNowPubSub::dump_config() {
   ESP_LOGCONFIG(TAG, "ESP-NOW PubSub:");
   ESP_LOGCONFIG(TAG, "  MAC Address: %s", mac_address_.c_str());
   ESP_LOGCONFIG(TAG, "  Channel: %d", channel_);
+  if (tx_power_ >= 0.0f) {
+    ESP_LOGCONFIG(TAG, "  TX Power: %.1f dBm", tx_power_);
+  }
   ESP_LOGCONFIG(TAG, "  WiFi Component Channel: %d", wifi_component_channel_);
   ESP_LOGCONFIG(TAG, "  WiFi Channel Compatible: %s", wifi_channel_compatible_ ? "YES" : "NO");
   if (!wifi_channel_compatible_) {

--- a/components/espnow_pubsub/espnow_pubsub.h
+++ b/components/espnow_pubsub/espnow_pubsub.h
@@ -57,6 +57,7 @@ class EspNowPubSub : public Component {
   void dump_config() override;
 
   void set_channel(int channel) { channel_ = channel; }
+  void set_tx_power(float tx_power) { tx_power_ = tx_power; }
 
   // Only compile-time subscriptions via add_subscription
   void add_subscription(const std::string &topic, OnMessageTrigger *trigger);
@@ -87,6 +88,7 @@ class EspNowPubSub : public Component {
 
  protected:
   int channel_{1};
+  float tx_power_{-1.0f};
   struct Subscription {
     std::string topic;
     MessageCallback callback;


### PR DESCRIPTION
## Summary
- allow configuring ESP-NOW transmit power
- document new tx_power option

## Testing
- `python -m py_compile components/espnow_pubsub/__init__.py components/espnow_pubsub/sensor.py components/espnow_pubsub/text_sensor.py`
- `g++ -std=c++17 -fsyntax-only components/espnow_pubsub/espnow_pubsub.cpp` *(fails: fatal error: esp_now.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b060f1221883279f8df9a53c4523ae